### PR TITLE
Fixes for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text eol=lf
+
+*.cmd text eol=crlf
+
+*.jar     binary

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+
+### MariaDB database files ###
+/database/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ COPY pom.xml /opt/app/
 COPY mvnw /opt/app/
 COPY .mvn /opt/app/.mvn
 COPY src /opt/app/src
-RUN cd /opt/app && ./mvnw -f pom.xml clean package
+RUN cd /opt/app && bash ./mvnw -f pom.xml clean package


### PR DESCRIPTION
This PR include two fixes for Windows:
* Permissions: cannot execute the bash script `mvnw` because of inadequate permissions (due to Windows). The fix is to pass the script as an arg to `bash`, therefore bypassing the permission prerequisite.
* End of line sequence: on my Windows machine, checked out files were converted to CRLF, which breaks the `mvnw` script. The fix is to add a `.gitattributes` file which override git `eol` settings for this repo, independently from the OS and global git config.

This PR also adds the `database` folder to .gitignore. This folder is the one mapped inside the mariadb container, in which the database files are persisted.
